### PR TITLE
feat: introduce dock-mode="sticky"

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ export default () => {
     <option value="hidden">hidden</option>
     <option value="inline" selected>inline</option>
     <option value="dock">dock</option>
-    <option value="sticky">sticky</option>
     <option value="lightbox">lightbox</option>
     <option value="custom-value">custom-value</option>
   </select>
@@ -120,7 +119,6 @@ export default () => {
     <option value="hidden">hidden</option>
     <option value="inline" selected>inline</option>
     <option value="dock">dock</option>
-    <option value="sticky">sticky</option>
     <option value="lightbox">lightbox</option>
   </select>
   <button onClick=${onButtonClick} class="button">Switch Dialog Mode</button>
@@ -180,7 +178,6 @@ export default () => {
     <option value="hidden">hidden</option>
     <option value="inline" selected>inline</option>
     <option value="dock">dock</option>
-    <option value="sticky">sticky</option>
     <option value="lightbox">lightbox</option>
   </select>
   <button onClick=${onButtonClick} class="button">Switch Dialog Mode</button>
@@ -228,8 +225,6 @@ export default () => {
     <option value="hidden" selected>hidden</option>
     <option value="inline">inline</option>
     <option value="dock">dock</option>
-    <option value="sticky">sticky</option>
-    <option value="sticky">sticky</option>
     <option value="lightbox">lightbox</option>
   </select>
   <button onClick=${onButtonClick} class="button">Switch Dialog Mode</button>
@@ -286,8 +281,6 @@ export default () => {
     <option value="hidden">hidden</option>
     <option value="inline" selected>inline</option>
     <option value="dock">dock</option>
-    <option value="sticky">sticky</option>
-    <option value="sticky">sticky</option>
     <option value="lightbox">lightbox</option>
   </select>
   <button onClick=${onButtonClick} class="button">Switch Dialog Mode</button>
@@ -389,7 +382,6 @@ export default () => {
     <option value="hidden">hidden</option>
     <option value="inline" selected>inline</option>
     <option value="dock">dock</option>
-    <option value="sticky">sticky</option>
     <option value="lightbox">lightbox</option>
   </select>
   <button onClick=${onButtonClick} class="button">Switch Dialog Mode</button>
@@ -482,7 +474,6 @@ export default () => {
     <option value="hidden">hidden</option>
     <option value="inline" selected>inline</option>
     <option value="dock">dock</option>
-    <option value="sticky">sticky</option>
     <option value="lightbox">lightbox</option>
   </select>
   <button onClick=${onButtonClick} class="button">Switch Dialog Mode</button>
@@ -526,9 +517,9 @@ export default () => {
 </glomex-dialog>
 ~~~
 
-### With IntersectionObserver and custom position
+### With IntersectionObserver and dock-mode = sticky
 
-This example auto docks the video element when the player gets scrolled out of view.
+This example auto docks the video element when the player gets scrolled out of view (similar to `position: sticky`).
 
 ```js preact
 import { html, render, useRef, useEffect } from 'docup'
@@ -536,7 +527,9 @@ import { html, render, useRef, useEffect } from 'docup'
 export default () => {
   const select = useRef();
   const dialog = useRef();
+  const dockMode = useRef();
   const onButtonClick = () => {
+    dialog.current.setAttribute('dock-mode', dockMode.current.value);
     dialog.current.setAttribute('mode', select.current.value);
   };
 
@@ -546,25 +539,26 @@ export default () => {
   useEffect(() => {
     const observer = new IntersectionObserver((entries) => {
       const glomexDialog = dialog.current;
+      glomexDialog.setAttribute('dock-mode', dockMode.current.value);
       currentIntersectionRatio = entries[0].intersectionRatio;
       if (!onceVisible) {
         onceVisible = entries[0].intersectionRatio === 1;
         return;
       }
       const currentMode = glomexDialog.getAttribute('mode');
-      const dockMode = select.current.value === 'sticky' ? 'sticky' : 'dock';
       if (currentMode === 'lightbox' || !currentMode) {
         return;
       }
       if (entries[0].intersectionRatio < 1 && (
-        currentMode !== dockMode
+        currentMode !== 'dock'
       )) {
-        glomexDialog.setAttribute('mode', dockMode);
+        glomexDialog.setAttribute('mode', 'dock');
       } else if (entries[0].intersectionRatio === 1) {
         glomexDialog.setAttribute('mode', 'inline');
       }
     }, {
-      threshold: [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]
+      threshold: [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1],
+      rootMargin: '-48px 0px 0px 0px'
     });
     if (dialog.current) {
       observer.observe(dialog.current);
@@ -578,16 +572,26 @@ export default () => {
 
   return html`
   <p>
-  <select ref=${select}>
-    <option value="hidden">hidden</option>
-    <option value="inline">inline</option>
-    <option value="dock" selected>dock</option>
-    <option value="sticky">sticky</option>
-    <option value="lightbox">lightbox</option>
-  </select>
+  <label>
+    Mode
+    <select style="margin-left:1em;" ref=${select}>
+      <option value="hidden">hidden</option>
+      <option value="inline">inline</option>
+      <option value="dock" selected>dock</option>
+      <option value="sticky">sticky</option>
+      <option value="lightbox">lightbox</option>
+    </select>
+  </label>
+  <label style="margin-left:1em;" >
+    Dock-Mode
+    <select style="margin-left:1em;" ref=${dockMode}>
+      <option value="">none</option>
+      <option value="sticky" selected>sticky</option>
+    </select>
+  </label>
   <button onClick=${onButtonClick} class="button">Switch Dialog Mode</button>
   </p>
-  <glomex-dialog ref=${dialog} mode="inline" dock-target-inset="48px 10px auto auto">
+  <glomex-dialog ref=${dialog} mode="inline" dock-target-inset="48px 10px auto auto" dock-sticky-target-top="48">
   <div slot="dialog-element">
     <div style="position: relative;">
       <div class="placeholder-16x9"></div>
@@ -608,7 +612,12 @@ export default () => {
 
 ~~~html
 <!-- The intersection-observer-code is custom in the above example -->
-<glomex-dialog mode="inline" dock-target-inset="50px 10px auto auto">
+<glomex-dialog
+  mode="inline"
+  dock-target-inset="50px 10px auto auto"
+  dock-mode="sticky"
+  dock-sticky-target-top="48"
+>
   <!-- ... -->
 </glomex-dialog>
 ~~~

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ export default () => {
     <option value="hidden">hidden</option>
     <option value="inline" selected>inline</option>
     <option value="dock">dock</option>
+    <option value="sticky">sticky</option>
     <option value="lightbox">lightbox</option>
     <option value="custom-value">custom-value</option>
   </select>
@@ -119,6 +120,7 @@ export default () => {
     <option value="hidden">hidden</option>
     <option value="inline" selected>inline</option>
     <option value="dock">dock</option>
+    <option value="sticky">sticky</option>
     <option value="lightbox">lightbox</option>
   </select>
   <button onClick=${onButtonClick} class="button">Switch Dialog Mode</button>
@@ -178,6 +180,7 @@ export default () => {
     <option value="hidden">hidden</option>
     <option value="inline" selected>inline</option>
     <option value="dock">dock</option>
+    <option value="sticky">sticky</option>
     <option value="lightbox">lightbox</option>
   </select>
   <button onClick=${onButtonClick} class="button">Switch Dialog Mode</button>
@@ -225,6 +228,8 @@ export default () => {
     <option value="hidden" selected>hidden</option>
     <option value="inline">inline</option>
     <option value="dock">dock</option>
+    <option value="sticky">sticky</option>
+    <option value="sticky">sticky</option>
     <option value="lightbox">lightbox</option>
   </select>
   <button onClick=${onButtonClick} class="button">Switch Dialog Mode</button>
@@ -281,6 +286,8 @@ export default () => {
     <option value="hidden">hidden</option>
     <option value="inline" selected>inline</option>
     <option value="dock">dock</option>
+    <option value="sticky">sticky</option>
+    <option value="sticky">sticky</option>
     <option value="lightbox">lightbox</option>
   </select>
   <button onClick=${onButtonClick} class="button">Switch Dialog Mode</button>
@@ -382,6 +389,7 @@ export default () => {
     <option value="hidden">hidden</option>
     <option value="inline" selected>inline</option>
     <option value="dock">dock</option>
+    <option value="sticky">sticky</option>
     <option value="lightbox">lightbox</option>
   </select>
   <button onClick=${onButtonClick} class="button">Switch Dialog Mode</button>
@@ -474,6 +482,7 @@ export default () => {
     <option value="hidden">hidden</option>
     <option value="inline" selected>inline</option>
     <option value="dock">dock</option>
+    <option value="sticky">sticky</option>
     <option value="lightbox">lightbox</option>
   </select>
   <button onClick=${onButtonClick} class="button">Switch Dialog Mode</button>
@@ -543,11 +552,14 @@ export default () => {
         return;
       }
       const currentMode = glomexDialog.getAttribute('mode');
+      const dockMode = select.current.value === 'sticky' ? 'sticky' : 'dock';
       if (currentMode === 'lightbox' || !currentMode) {
         return;
       }
-      if (entries[0].intersectionRatio < 1 && glomexDialog.getAttribute('mode') !== 'dock') {
-        glomexDialog.setAttribute('mode', 'dock');
+      if (entries[0].intersectionRatio < 1 && (
+        currentMode !== dockMode
+      )) {
+        glomexDialog.setAttribute('mode', dockMode);
       } else if (entries[0].intersectionRatio === 1) {
         glomexDialog.setAttribute('mode', 'inline');
       }
@@ -567,14 +579,15 @@ export default () => {
   return html`
   <p>
   <select ref=${select}>
-    <option value="hidden" selected>hidden</option>
+    <option value="hidden">hidden</option>
     <option value="inline">inline</option>
-    <option value="dock">dock</option>
+    <option value="dock" selected>dock</option>
+    <option value="sticky">sticky</option>
     <option value="lightbox">lightbox</option>
   </select>
   <button onClick=${onButtonClick} class="button">Switch Dialog Mode</button>
   </p>
-  <glomex-dialog ref=${dialog} mode="inline" dock-target-inset="50px 10px auto auto">
+  <glomex-dialog ref=${dialog} mode="inline" dock-target-inset="48px 10px auto auto">
   <div slot="dialog-element">
     <div style="position: relative;">
       <div class="placeholder-16x9"></div>

--- a/README.md
+++ b/README.md
@@ -529,9 +529,11 @@ export default () => {
   const dialog = useRef();
   const dockMode = useRef();
   const onButtonClick = () => {
-    dialog.current.setAttribute('dock-mode', dockMode.current.value);
     dialog.current.setAttribute('mode', select.current.value);
   };
+  const onDockModeChange = () => {
+    dialog.current.setAttribute('dock-mode', dockMode.current.value);
+  }
 
   let onceVisible = false;
   let currentIntersectionRatio;
@@ -539,7 +541,6 @@ export default () => {
   useEffect(() => {
     const observer = new IntersectionObserver((entries) => {
       const glomexDialog = dialog.current;
-      glomexDialog.setAttribute('dock-mode', dockMode.current.value);
       currentIntersectionRatio = entries[0].intersectionRatio;
       if (!onceVisible) {
         onceVisible = entries[0].intersectionRatio === 1;
@@ -584,14 +585,14 @@ export default () => {
   </label>
   <label style="margin-left:1em;" >
     Dock-Mode
-    <select style="margin-left:1em;" ref=${dockMode}>
+    <select onChange="${onDockModeChange}" style="margin-left:1em;" ref=${dockMode}>
       <option value="">none</option>
       <option value="sticky" selected>sticky</option>
     </select>
   </label>
   <button onClick=${onButtonClick} class="button">Switch Dialog Mode</button>
   </p>
-  <glomex-dialog ref=${dialog} mode="inline" dock-target-inset="48px 10px auto auto" dock-sticky-target-top="48">
+  <glomex-dialog ref=${dialog} mode="inline" dock-mode="sticky" dock-target-inset="48px 10px auto auto" dock-sticky-target-top="48">
   <div slot="dialog-element">
     <div style="position: relative;">
       <div class="placeholder-16x9"></div>

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -33,22 +33,67 @@
           ],
           "attributes": [
             {
-              "name": "mode"
+              "name": "mode",
+              "type": {
+                "text": "string"
+              },
+              "description": "Can take the values \"hidden\", \"inline\", \"dock\", \"lightbox\" or \"sticky\""
             },
             {
-              "name": "aspect-ratio"
+              "name": "aspect-ratio",
+              "type": {
+                "text": "string"
+              },
+              "description": "The aspect-ratio for the inline element. Default is 16:9"
             },
             {
-              "name": "dock-target"
+              "name": "dock-target",
+              "type": {
+                "text": "string"
+              },
+              "description": "A dom-element with position:fixed where mode=dock should animate to"
             },
             {
-              "name": "dock-target-inset"
+              "name": "dock-target-inset",
+              "type": {
+                "text": "string"
+              },
+              "description": "Allows positions the dock target (which corner to dock to)"
             },
             {
-              "name": "dock-aspect-ratio"
+              "name": "dock-aspect-ratio",
+              "type": {
+                "text": "string"
+              },
+              "description": "The aspect-ratio when the element is mode=dock"
             },
             {
-              "name": "dock-downscale"
+              "name": "dock-sticky-target-top",
+              "type": {
+                "text": "string"
+              },
+              "description": "The top distance for mode=sticky in pixels (defaults to 0)"
+            },
+            {
+              "name": "dock-sticky-aspect-ratio",
+              "type": {
+                "text": "string"
+              },
+              "description": "The aspect-ratio when the element is mode=sticky"
+            },
+            {
+              "name": "dock-downscale",
+              "type": {
+                "text": "string"
+              },
+              "description": "Do you want to scale the element when mode=dock"
+            },
+            {
+              "name": "dock-transition-duration",
+              "type": {
+                "text": "string"
+              },
+              "description": "Time to animate from inline to dock and back in milliseconds (default is 300ms)"
             }
           ],
           "superclass": {

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -58,7 +58,7 @@
               "type": {
                 "text": "string"
               },
-              "description": "Allows positions the dock target (which corner to dock to)"
+              "description": "Defines the position of the dock using inset"
             },
             {
               "name": "dock-aspect-ratio",

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -87,13 +87,6 @@
                 "text": "string"
               },
               "description": "Do you want to scale the element when mode=dock"
-            },
-            {
-              "name": "dock-transition-duration",
-              "type": {
-                "text": "string"
-              },
-              "description": "Time to animate from inline to dock and back in milliseconds (default is 300ms)"
             }
           ],
           "superclass": {

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -37,7 +37,7 @@
               "type": {
                 "text": "string"
               },
-              "description": "Can take the values \"hidden\", \"inline\", \"dock\", \"lightbox\" or \"sticky\""
+              "description": "Can take the values \"hidden\", \"inline\", \"dock\" or \"lightbox\"."
             },
             {
               "name": "aspect-ratio",
@@ -68,18 +68,25 @@
               "description": "The aspect-ratio when the element is mode=dock"
             },
             {
+              "name": "dock-mode",
+              "type": {
+                "text": "string"
+              },
+              "description": "When set to \"sticky\" it behaves similar to \"position: sticky\" in CSS (with a max width of 400px). If undefined docks the content to a corner."
+            },
+            {
               "name": "dock-sticky-target-top",
               "type": {
                 "text": "string"
               },
-              "description": "The top distance for mode=sticky in pixels (defaults to 0)"
+              "description": "The top distance for dock-mode=sticky in pixels (defaults to 0)"
             },
             {
               "name": "dock-sticky-aspect-ratio",
               "type": {
                 "text": "string"
               },
-              "description": "The aspect-ratio when the element is mode=sticky"
+              "description": "The aspect-ratio when the element is docked for dock-mode=sticky"
             },
             {
               "name": "dock-downscale",

--- a/glomex-dialog.js
+++ b/glomex-dialog.js
@@ -84,6 +84,9 @@ const moveFromTo = (element, {
   element.style.position = 'fixed';
   element.style.width = `${width}px`;
   element.style.height = `${height}px`;
+  element.style.transform = 'scale(1)';
+  element.firstElementChild.style.transform = 'scale(1)';
+
   if (navigator.userAgent.indexOf('Safari') !== -1 && navigator.userAgent.indexOf('Chrome') === -1) {
     // somehow safari animates to the wrong position initially
     // and then snaps into place when the aspect-ratio is not stable
@@ -92,8 +95,6 @@ const moveFromTo = (element, {
 
   element.style.top = `${fromRect.top + visualViewport.offsetTop}px`;
   element.style.left = `${fromRect.left + visualViewport.offsetLeft}px`;
-  element.style.transform = 'scale(1.001)';
-  element.style.overflow = 'hidden';
 
   const deltaX = toRect.left - fromRect.left;
   const deltaY = toRect.top - fromRect.top;
@@ -108,7 +109,7 @@ const moveFromTo = (element, {
     if (!downscale) {
       element.firstElementChild.style.width = `${toRect.width}px`;
       element.firstElementChild.style.transform = `scale(${1 / deltaScale})`;
-      element.firstElementChild.style.transitionProperty = 'width';
+      element.firstElementChild.style.transitionProperty = 'scale';
       element.firstElementChild.style.transformOrigin = 'top left';
       element.firstElementChild.style.transitionTimingFunction = 'ease-out';
     }
@@ -240,7 +241,6 @@ class GlomexDialogElement extends window.HTMLElement {
 
     .aspect-ratio-box {
       height: 0;
-      overflow: hidden;
     }
 
     .placeholder {
@@ -283,7 +283,9 @@ class GlomexDialogElement extends window.HTMLElement {
     }
 
     .dialog-inverse-scale-element {
-      will-change: transform, transition, width, height, top, left, opacity;
+      width: 100%;
+      max-height: 100%;
+      will-change: transform, width, height;
       transform-origin: top left;
     }
 
@@ -312,7 +314,6 @@ class GlomexDialogElement extends window.HTMLElement {
 
     :host([mode=dock]) .dialog-content,
     :host([mode=sticky]) .dialog-content {
-      contain: strict;
       position: absolute;
     }
 
@@ -604,9 +605,9 @@ class GlomexDialogElement extends window.HTMLElement {
           // position "fixed" => "absolute"
           dialogContent.style.display = 'grid';
           dialogContent.style.position = 'absolute';
-          dialogContent.style.transform = 'scale(1.001)';
-          dialogContent.firstElementChild.style.transform = null;
-          dialogContent.firstElementChild.style.width = null;
+          dialogContent.style.transform = 'scale(1)';
+          dialogContent.firstElementChild.style.transform = 'scale(1)';
+          dialogContent.firstElementChild.style.width = null
           dialogContent.style.top = null;
           dialogContent.style.left = null;
           if (!this._wasInHiddenMode && (oldValue === 'dock' || oldValue === 'sticky')) {
@@ -755,8 +756,13 @@ class GlomexDialogElement extends window.HTMLElement {
       ? getAlternativeDockTarget(this) || getDefaultDockTarget(this)
       : getDockStickyTarget(this);
 
-    dockStickyTarget.style.width = `${clientRect.width}px`;
-    dockStickyTarget.style.height = `${clientRect.height}px`;
+    let stickyWidth = clientRect.width;
+    if (stickyWidth >= MAX_DOCK_WIDTH) {
+      stickyWidth = MAX_DOCK_WIDTH;
+    }
+
+    dockStickyTarget.style.width = `${stickyWidth}px`;
+    dockStickyTarget.style.height = `${clientRect.height * (stickyWidth / clientRect.width)}px`;
 
     const aspectRatios = [
       this.getAttribute('mode') === 'sticky'

--- a/glomex-dialog.js
+++ b/glomex-dialog.js
@@ -215,8 +215,6 @@ function isInDocument(element, document) {
  *   (defaults to 0)
  * @attr {string} dock-sticky-aspect-ratio - The aspect-ratio when the element is mode=sticky
  * @attr {string} dock-downscale - Do you want to scale the element when mode=dock
- * @attr {string} dock-transition-duration - Time to animate from inline to dock and back
- *   in milliseconds (default is 300ms)
  */
 class GlomexDialogElement extends window.HTMLElement {
   constructor() {
@@ -551,8 +549,7 @@ class GlomexDialogElement extends window.HTMLElement {
     let aspectRatios;
     const dialogContent = this.shadowRoot.querySelector('.dialog-content');
     const placeholder = this.shadowRoot.querySelector('.placeholder');
-    const transitionDuration = this.getAttribute('dock-transition-duration')
-      || DEFAULT_TRANSITION_DURATION;
+    const transitionDuration = DEFAULT_TRANSITION_DURATION;
     if (name === 'mode') {
       if (this._wasInHiddenMode && (
         newValue === 'lightbox'

--- a/glomex-dialog.js
+++ b/glomex-dialog.js
@@ -704,6 +704,10 @@ class GlomexDialogElement extends window.HTMLElement {
       this.refreshDockDialog();
     }
 
+    if (name === 'dock-mode') {
+      this.refreshDockDialog();
+    }
+
     if (name === 'aspect-ratio') {
       updatePlaceholderAspectRatio(this, getAspectRatioFromStrings([
         this.getAttribute('aspect-ratio'),

--- a/glomex-dialog.js
+++ b/glomex-dialog.js
@@ -279,15 +279,17 @@ class GlomexDialogElement extends window.HTMLElement {
       display: block;
       position: absolute;
       top: 0;
-      right: 0;
-      bottom: 0;
       left: 0;
+      width: 100%;
+      height: 100%;
+      max-width: 100%;
       will-change: transform, transition, width, height, top, left, opacity;
     }
 
     .dialog-inverse-scale-element {
       width: 100%;
       max-height: 100%;
+      max-width: 100%;
       will-change: transform, width, height;
       transform-origin: top left;
     }

--- a/glomex-dialog.js
+++ b/glomex-dialog.js
@@ -210,7 +210,7 @@ function isInDocument(element, document) {
  * @attr {string} mode - Can take the values "hidden", "inline", "dock" or "lightbox".
  * @attr {string} aspect-ratio - The aspect-ratio for the inline element. Default is 16:9
  * @attr {string} dock-target - A dom-element with position:fixed where mode=dock should animate to
- * @attr {string} dock-target-inset - Allows positions the dock target (which corner to dock to)
+ * @attr {string} dock-target-inset - Defines the position of the dock using inset
  * @attr {string} dock-aspect-ratio - The aspect-ratio when the element is mode=dock
  * @attr {string} dock-mode - When set to "sticky" it behaves similar to "position: sticky" in CSS
  *   (with a max width of 400px). If undefined docks the content to a corner.

--- a/glomex-dialog.js
+++ b/glomex-dialog.js
@@ -543,7 +543,6 @@ class GlomexDialogElement extends window.HTMLElement {
       'dock-sticky-target-top',
       'dock-sticky-aspect-ratio',
       'dock-downscale',
-      'dock-transition-duration',
     ];
   }
 

--- a/glomex-dialog.js
+++ b/glomex-dialog.js
@@ -607,7 +607,7 @@ class GlomexDialogElement extends window.HTMLElement {
           dialogContent.style.position = 'absolute';
           dialogContent.style.transform = 'scale(1)';
           dialogContent.firstElementChild.style.transform = 'scale(1)';
-          dialogContent.firstElementChild.style.width = null
+          dialogContent.firstElementChild.style.width = null;
           dialogContent.style.top = null;
           dialogContent.style.left = null;
           if (!this._wasInHiddenMode && (oldValue === 'dock' || oldValue === 'sticky')) {

--- a/glomex-dialog.js
+++ b/glomex-dialog.js
@@ -603,6 +603,9 @@ class GlomexDialogElement extends window.HTMLElement {
         });
       } else if (newValue === 'inline') {
         const goToInline = () => {
+          // somehow this avoids CLS when switching between
+          // position "fixed" => "absolute"
+          dialogContent.style.display = 'grid';
           dialogContent.style.position = 'absolute';
           dialogContent.style.transform = 'scale(1.001)';
           dialogContent.firstElementChild.style.transform = null;

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <title>glomex-dialog</title>
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@egoist/docup@1/dist/docup.min.css"
+      href="https://unpkg.com/@egoist/docup@2/dist/docup.min.css"
     />
     <style>
       :root {


### PR DESCRIPTION
which positions contained element similar to `position: sticky;` using `dock-sticky-target-top` as top value and `dock-sticky-aspect-ratio` to define a separate aspect-ratio for the "sticky" dock-mode.

It also ensures that the sticky element only uses a maximum width of 400px.